### PR TITLE
ubuntu.yml: Install latest version of Lima

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,7 +17,6 @@ jobs:
 #        os: [ubuntu-24.04, ubuntu-24.04-arm]
       fail-fast: false
     env:
-      LIMA_VERSION: "v1.0.4"
       LIMA_USER: "lima"
     name: NixOS Lima on ${{ matrix.os }}
     steps:
@@ -41,11 +40,14 @@ jobs:
           LIMA_ARCH: ${{ matrix.os == 'ubuntu-24.04' && 'x86_64' || (matrix.os == 'ubuntu-24.04-arm' && 'aarch64') || 'unknown' }}
         run: |
           set -eux
+          LIMA_VERSION=$(curl -fsSL https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
           FILE="lima-${LIMA_VERSION:1}-Linux-${LIMA_ARCH}.tar.gz"
           curl -fOSL https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/${FILE}
           gh attestation verify --owner=lima-vm "${FILE}"
           sudo tar Cxzvf /usr/local "${FILE}"
           rm -f "${FILE}"
+          # Export LIMA_VERSION For the GHA cache key
+          echo "LIMA_VERSION=${LIMA_VERSION}" >>$GITHUB_ENV
 
       - name: "Cache ~/.cache/lima"
         uses: actions/cache@v4


### PR DESCRIPTION
Use a GitHub API request to determine latest Lima version before installing.

This PR is just a test to make sure https://github.com/lima-vm/lima/pull/3165 works correctly.

For this project, I prefer for LIMA_VERSION to be pinned and updated manually.
