### PR TITLE
GHA ubuntu.yml: Use matrix.os in the artifact name

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -73,6 +73,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-lima-errlog
+          name: artifacts-${{ matrix.os }}-lima-errlog
           path: ~/.lima/nixsample/*.log
 


### PR DESCRIPTION
This is important because when more than one matrix.os is used there is an artifact name collision.