### PR TITLE
GHA ubuntu.yml: Add guest-arch to matrix

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,13 +13,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
+        guest-arch: ['aarch64', 'x86_64']
       fail-fast: false
     env:
       # HOST_ARCH value must match string in Lima download filename
       HOST_ARCH: ${{ matrix.os == 'ubuntu-24.04' && 'x86_64' || (matrix.os == 'ubuntu-24.04-arm' && 'aarch64') || 'unknown' }}
       LIMA_VERSION: "v1.0.6"
-      LIMA_USER: "lima"
-    name: NixOS Lima on ${{ matrix.os }}
+      GUEST_HOST_NAME: "nixsample"
+      GUEST_USER: "lima"
+    name: NixOS-${{ matrix.guest-arch }} Lima on ${{ matrix.os }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -50,7 +52,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/lima
-          key: lima-${{ env.LIMA_VERSION }}
+          key: os-${{ matrix.os }}-NixOS-Lima-${{ env.LIMA_VERSION }}-guest-${{ matrix.guest-arch }}
 
       - name: "Start an instance of NixOS"
         env:
@@ -58,23 +60,23 @@ jobs:
           QEMU_SYSTEM_AARCH64: ${{ env.HOST_ARCH == 'aarch64' && 'qemu-system-aarch64 -machine virt -cpu max' || 'qemu-system-aarch64' }}
         run: |
           set -eux
-          limactl start --name=nixsample --network=lima:user-v2 --set '.user.name = "${{ env.LIMA_USER }}"' nixos.yaml
+          limactl start --arch ${{ matrix.guest-arch }} --name=${{ env.GUEST_HOST_NAME }} --network=lima:user-v2 --set '.user.name = "${{ env.GUEST_USER }}"' nixos.yaml
 
       - name: "Update and Rebuild NixOS"
         run: |
           set -eux
-          ./setup-rebuild-nixos.sh nixsample ${{ env.LIMA_USER }} sample
+          ./setup-rebuild-nixos.sh ${{ env.GUEST_HOST_NAME }} ${{ env.GUEST_USER }} ${{ env.GUEST_HOST_NAME }}-${{ matrix.guest-arch }}
 
       - name: "Initialize Home Manager"
         if: false # Disable for now to try to avoid timeouts
         run: |
           set -eux
-          ./setup-home-manager.sh nixsample ${{ env.LIMA_USER }}
+          ./setup-home-manager.sh ${{ env.GUEST_HOST_NAME }}  ${{ env.GUEST_USER }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-${{ matrix.os }}-lima-errlog
-          path: ~/.lima/nixsample/*.log
+          name: artifacts-os-${{ matrix.os }}-guest-${{ matrix.guest-arch }}-lima-errlog
+          path: ~/.lima/${{ env.GUEST_HOST_NAME }}/*.log
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,14 +16,23 @@
       system = "aarch64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
     in {
-        nixosConfigurations.sample = nixpkgs.lib.nixosSystem {
-          inherit system;
+        nixosConfigurations.nixsample-aarch64 = nixpkgs.lib.nixosSystem {
+          system = "aarch64-linux";
           # Pass the `limainit` input along with the default module system parameters
           specialArgs = { inherit limainit; };
           modules = [
             ./nixos-lima-config.nix
           ];
         };
+        nixosConfigurations.nixsample-x86_64 = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          # Pass the `limainit` input along with the default module system parameters
+          specialArgs = { inherit limainit; };
+          modules = [
+            ./nixos-lima-config.nix
+          ];
+        };
+
         # You'll need to change the configuration name to match the username
         # that Lima automatically creates (same as your host username)
         homeConfigurations."lima" = home-manager.lib.homeManagerConfiguration {


### PR DESCRIPTION
Add guest-arch to the matrix to build the guest as either aarch64 or x86_64. Parameterize `limactl start` and update build name and Lima Cache key as well.