### PR TITLE
nixos.yaml: use default mountType in nixos.yaml

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -60,7 +60,7 @@ jobs:
           QEMU_SYSTEM_AARCH64: ${{ env.HOST_ARCH == 'aarch64' && 'qemu-system-aarch64 -machine virt -cpu max' || 'qemu-system-aarch64' }}
         run: |
           set -eux
-          limactl start --arch ${{ matrix.guest-arch }} --name=${{ env.GUEST_HOST_NAME }} --network=lima:user-v2 --set '.user.name = "${{ env.GUEST_USER }}"' nixos.yaml
+          limactl start --vm-type qemu --arch ${{ matrix.guest-arch }} --name=${{ env.GUEST_HOST_NAME }} --network=lima:user-v2 --set '.user.name = "${{ env.GUEST_USER }}"' nixos.yaml
 
       - name: "Update and Rebuild NixOS"
         run: |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ NOTE: Nix is not needed to run a NixOS Lima VM (e.g. you can install Lima with H
 Check out this repository to your Lima host. The following commands can be used with no customization of this repository. (The main username for the guest VM, "lima" is hardcoded in `flake.nix`.)
 
 ```
-limactl start --name=nixsample --tty=false  --set '.user.name = "lima"' nixos.yaml
+limactl start --vm-type qemu --name=nixsample --tty=false  --set '.user.name = "lima"' nixos.yaml
 ./setup-home-manager.sh nixsample lima sample
 ./setup-nixos.sh nixsample lima
 ```
@@ -27,7 +27,7 @@ limactl start --name=nixsample --tty=false  --set '.user.name = "lima"' nixos.ya
 If you create a fork or copy of this repo, or use your own Home Manager flake, you would likely use the same username as you use on the host system, so in that case the commands would be simpler:                             
 
 ```
-limactl start --name=nixsample --tty=false nixos.yaml
+limactl start --vm-type qemu --name=nixsample --tty=false nixos.yaml
 ./setup-home-manager.sh nixsample $USER sample
 ./setup-nixos.sh nixsample
 ```

--- a/nixos.yaml
+++ b/nixos.yaml
@@ -19,8 +19,6 @@ mounts:
   9p:
     cache: "mmap"
 
-mountType: "9p"
-
 ssh:
   # This allows access to GitHub, etc.
   forwardAgent: true


### PR DESCRIPTION
With `mountType` no longer set to `"9p"`, Lima will default to `vmType: "vz"`, so `README.md` is updated to add `--vm-type qemu` to the `limactl start` commands.

Note that `nixos-lima` doesn't support `vz` yet, but it  should be added soon and this change helps prepare for that. README.md