### PR TITLE
GHA ubuntu.yml: More consistent instance-related naming

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -19,7 +19,8 @@ jobs:
       # HOST_ARCH value must match string in Lima download filename
       HOST_ARCH: ${{ matrix.os == 'ubuntu-24.04' && 'x86_64' || (matrix.os == 'ubuntu-24.04-arm' && 'aarch64') || 'unknown' }}
       LIMA_VERSION: "v1.0.7"
-      GUEST_HOST_NAME: "nixsample"
+      LIMA_GUEST_NAME: "nixsample"
+      NIX_CONFIG_BASE: "nixsample"
       GUEST_USER: "lima"
     name: NixOS-${{ matrix.guest-arch }} Lima on ${{ matrix.os }}
     steps:
@@ -56,23 +57,23 @@ jobs:
           QEMU_SYSTEM_AARCH64: ${{ env.HOST_ARCH == 'aarch64' && 'qemu-system-aarch64 -machine virt -cpu max' || 'qemu-system-aarch64' }}
         run: |
           set -eux
-          limactl start --arch ${{ matrix.guest-arch }} --name=${{ env.GUEST_HOST_NAME }} --network=lima:user-v2 --set '.user.name = "${{ env.GUEST_USER }}"' nixos.yaml
+          limactl start --arch ${{ matrix.guest-arch }} --name=${{ env.LIMA_GUEST_NAME }} --network=lima:user-v2 --set '.user.name = "${{ env.GUEST_USER }}"' nixos.yaml
 
       - name: "Update and Rebuild NixOS"
         run: |
           set -eux
-          ./setup-nixos.sh ${{ env.GUEST_HOST_NAME }} ${{ env.GUEST_USER }} ${{ env.GUEST_HOST_NAME }}-${{ matrix.guest-arch }}
+          ./setup-nixos.sh ${{ env.LIMA_GUEST_NAME }} ${{ env.GUEST_USER }} ${{ env.NIX_CONFIG_BASE }}-${{ matrix.guest-arch }}
 
       - name: "Initialize Home Manager"
         if: false # Disable for now to try to avoid timeouts
         run: |
           set -eux
-          ./setup-home-manager.sh ${{ env.GUEST_HOST_NAME }}  ${{ env.GUEST_USER }}
+          ./setup-home-manager.sh ${{ env.LIMA_GUEST_NAME }}  ${{ env.GUEST_USER }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: artifacts-os-${{ matrix.os }}-guest-${{ matrix.guest-arch }}-lima-errlog
-          path: ~/.lima/${{ env.GUEST_HOST_NAME }}/*.log
+          path: ~/.lima/${{ env.LIMA_GUEST_NAME }}/*.log
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NOTE: Nix is not needed to run a NixOS Lima VM (e.g. you can install Lima with H
 
 ## Installation
 
-Check out this repository to your Lima host. The following commands can be used with no customization of this repository. (The main username for the guest VM, "lima" is hardcoded in `flake.nix`.)
+Check out this repository to your Lima host. The following commands can be used with no customization of this repository. (The main username for the guest VM, "lima" is hardcoded in `homeConfigurations."lima"` in `flake.nix`.)
 
 ```
 limactl start --yes --set '.user.name = "lima"' nixos.yaml

--- a/nixos-lima-config.nix
+++ b/nixos-lima-config.nix
@@ -9,7 +9,7 @@
       nixos-lima.nixosModules.lima
     ];
 
-    networking.hostName = "sample";
+    networking.hostName = "nixsample";
 
     # TODO: Consider setting some/all of the mandatory settings in `nixos-lima.nixosModules.lima`
 


### PR DESCRIPTION
* Rename the `GUEST_HOST_NAME` variable to `LIMA_GUEST_NAME` since the hostname of the image is set independently (and is initially `nixos` then gets set to the name in the NixOS config by `setup-nixos.sh`)

* Add `NIX_CONFIG_BASE` for the base name of the host config in `flake.nix`

* nixos-lima-config.nix: Change `networking.hostName` to `nixsample`