### PR TITLE
GHA ubuntu.yml: set additional_guestagents to 'true'

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -43,7 +43,7 @@ jobs:
         id: lima-actions-setup
         with:
           version: ${{ env.LIMA_VERSION }}
-          additional_guestagents: ${{ matrix.os == 'ubuntu-24.04' && 'false' || (matrix.os == 'ubuntu-24.04-arm' && 'true') || 'false' }}
+          additional_guestagents: 'true'
 
       - name: "Cache ~/.cache/lima"
         uses: actions/cache@v4


### PR DESCRIPTION
The conditional did not seem to be working properly and is not worth the aggravation. See Issue #37 

Edit: the conditional was working properly, it's just that the `additional_guestagents` only takes affect with Lima 1.1.0-rc.0 or later.