### PR TITLE
GHA ubuntu.yml: Bump to Lima 2.0.3, fix additional_guestagents conditional

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       # HOST_ARCH value must match string in Lima download filename
       HOST_ARCH: ${{ matrix.os == 'ubuntu-24.04' && 'x86_64' || (matrix.os == 'ubuntu-24.04-arm' && 'aarch64') || 'unknown' }}
-      LIMA_VERSION: "v1.1.1"
+      LIMA_VERSION: "v1.2.3"
       LIMA_GUEST_NAME: "nixsample"
       NIX_CONFIG_BASE: "nixsample"
       GUEST_USER: "lima"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       # HOST_ARCH value must match string in Lima download filename
       HOST_ARCH: ${{ matrix.os == 'ubuntu-24.04' && 'x86_64' || (matrix.os == 'ubuntu-24.04-arm' && 'aarch64') || 'unknown' }}
-      LIMA_VERSION: "v1.2.3"
+      LIMA_VERSION: "v2.0.3"
       LIMA_GUEST_NAME: "nixsample"
       NIX_CONFIG_BASE: "nixsample"
       GUEST_USER: "lima"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       # HOST_ARCH value must match string in Lima download filename
       HOST_ARCH: ${{ matrix.os == 'ubuntu-24.04' && 'x86_64' || (matrix.os == 'ubuntu-24.04-arm' && 'aarch64') || 'unknown' }}
-      LIMA_VERSION: "v1.1.0-beta.0"
+      LIMA_VERSION: "v1.1.0-rc.0"
       LIMA_GUEST_NAME: "nixsample"
       NIX_CONFIG_BASE: "nixsample"
       GUEST_USER: "lima"
@@ -45,7 +45,7 @@ jobs:
         id: lima-actions-setup
         with:
           version: ${{ env.LIMA_VERSION }}
-          additional_guestagents: ${{ matrix.os == 'ubuntu-24.04' && 'false' || (matrix.os == 'ubuntu-24.04-arm' && 'true') || 'false' }}
+          additional_guestagents: ${{ matrix.os == 'ubuntu-24.04' && matrix.guest-arch == 'aarch64' && 'true' || (matrix.os == 'ubuntu-24.04-arm' && 'true') || 'false' }}
 
       - name: "Cache ~/.cache/lima"
         uses: actions/cache@v4

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       # HOST_ARCH value must match string in Lima download filename
       HOST_ARCH: ${{ matrix.os == 'ubuntu-24.04' && 'x86_64' || (matrix.os == 'ubuntu-24.04-arm' && 'aarch64') || 'unknown' }}
-      LIMA_VERSION: "v1.1.0-rc.0"
+      LIMA_VERSION: "v1.1.1"
       LIMA_GUEST_NAME: "nixsample"
       NIX_CONFIG_BASE: "nixsample"
       GUEST_USER: "lima"


### PR DESCRIPTION
1.1.0-rc.0 is the release that splits out the guest agents, so in order to upgrade to it we need to fix our broken conditional.

We currently need `additional_guestagents` only for `aarch64` on `ubuntu-24.04` (x86_64) so check for that first.

Follow-on commit upgrade to Lima 2.0.3