### PR TITLE
flake.nix: pass nixos-lima to system configs in `modules` list

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,17 +21,15 @@
     in {
         nixosConfigurations.nixsample-aarch64 = nixpkgs.lib.nixosSystem {
           system = "aarch64-linux";
-          # Pass the `nixos-lima` input along with the default module system parameters
-          specialArgs = { inherit nixos-lima; };
           modules = [
+            nixos-lima.nixosModules.lima
             ./nixos-lima-config.nix
           ];
         };
         nixosConfigurations.nixsample-x86_64 = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
-          # Pass the `nixos-lima` input along with the default module system parameters
-          specialArgs = { inherit nixos-lima; };
           modules = [
+            nixos-lima.nixosModules.lima
             ./nixos-lima-config.nix
           ];
         };
@@ -57,5 +55,5 @@
           # Optionally use extraSpecialArgs
           # to pass through arguments to home.nix
         };
-    };    
+    };
 }

--- a/nixos-lima-config.nix
+++ b/nixos-lima-config.nix
@@ -1,12 +1,10 @@
-{ config, modulesPath, pkgs, lib, nixos-lima,... }:
+{ config, modulesPath, pkgs, lib, ... }:
 {
     #
     # This is a sample configuration module for a NixOS Lima VM
     #
     imports = [
       (modulesPath + "/profiles/qemu-guest.nix")
-      # The `lima` module sets up systemd services to support LimaVM
-      nixos-lima.nixosModules.lima
     ];
 
     networking.hostName = "nixsample";


### PR DESCRIPTION
It's better to pass the nixos-lima module to `nixos-lima-config.nix` in the `modules` list, than to use `specialArgs` and then have to import it explicitly in `nixos-lima-config.nix`.